### PR TITLE
Remove hyphens

### DIFF
--- a/frontend/src/content/Content.js
+++ b/frontend/src/content/Content.js
@@ -18,6 +18,7 @@ class Content extends React.Component {
             }
         };
         this.onCaseChange = this.onCaseChange.bind(this)
+        this.removeHyphens = this.removeHyphens.bind(this)
     }
 
     componentDidMount() {
@@ -61,7 +62,26 @@ class Content extends React.Component {
                 isUppercase: stateToSet,
                 uuid: uuidToSet,
                 isLoaded: true,
+                version: this.state.items.version,
+                isHyphenated: this.state.items.isHyphenated,
+                isNumeric: this.state.items.isNumeric,
         }})
+    }
+
+    removeHyphens() {
+        let uuidToSet
+        if (this.state.items.uuid.includes("-"))    {
+            uuidToSet = this.state.items.uuid.replaceAll("-", "")
+        }
+        this.setState({
+            items:  {
+                isHyphenated: false,
+                uuid: uuidToSet,
+                isLoaded: true,
+                version: this.state.items.version,
+                isUppercase: this.state.items.isUppercase,
+                isNumeric: this.state.items.isNumeric,
+            }})
     }
 
     render() {
@@ -71,7 +91,10 @@ class Content extends React.Component {
                 <Instructions />
                 <Uuid item={this.state.items}/>
                 <ContentButtons />
-                <UuidChoices onChange={this.onCaseChange} />
+                <UuidChoices
+                    onCaseChange={this.onCaseChange}
+                    removeHyphens={this.removeHyphens}
+                />
             </Container>
         );
     }

--- a/frontend/src/content/Content.js
+++ b/frontend/src/content/Content.js
@@ -69,7 +69,8 @@ class Content extends React.Component {
     }
 
     removeHyphens() {
-        let uuidToSet
+        //TODO: Figure out how to bring back hyphens?
+        let uuidToSet = this.state.items.uuid
         if (this.state.items.uuid.includes("-"))    {
             uuidToSet = this.state.items.uuid.replaceAll("-", "")
         }

--- a/frontend/src/content/UuidOptions.js
+++ b/frontend/src/content/UuidOptions.js
@@ -1,4 +1,4 @@
-import {Checkbox, FormControlLabel, FormGroup} from "@mui/material";
+import {Checkbox, FormControl, FormControlLabel, FormGroup, FormHelperText} from "@mui/material";
 import * as React from "react";
 import Box from "@mui/material/Box";
 
@@ -7,6 +7,10 @@ class UuidChoices extends React.Component   {
         super(props);
         this.handleCaseChange = this.handleCaseChange.bind(this)
         this.removeHyphens = this.removeHyphens.bind(this)
+        this.state = {
+            error: null,
+            isHyphenated: true,
+        }
     }
 
     handleCaseChange()  {
@@ -14,7 +18,11 @@ class UuidChoices extends React.Component   {
     }
 
     removeHyphens() {
-       this.props.removeHyphens();
+        this.props.removeHyphens();
+        this.setState({
+            error: null,
+            isHyphenated: false,
+        })
     }
 
     render()    {
@@ -27,13 +35,16 @@ class UuidChoices extends React.Component   {
                 p: 3,
                 m: 2,
             }}>
-                <FormGroup row sx={{
-                    justifyContent: 'space-evenly'
-                }}>
-                    <FormControlLabel control={<Checkbox />} label="Uppercase" onChange={this.handleCaseChange} />
-                    <FormControlLabel control={<Checkbox />} label="Remove hyphens" onChange={this.removeHyphens} />
-                    <FormControlLabel control={<Checkbox />} label="Numbers only" />
-                </FormGroup>
+                <FormControl>
+                    <FormGroup row sx={{
+                        justifyContent: 'space-evenly'
+                    }}>
+                        <FormControlLabel control={<Checkbox />} label="Uppercase" onChange={this.handleCaseChange} />
+                        <FormControlLabel control={<Checkbox />} label="Remove hyphens" onChange={this.removeHyphens} disabled={!this.state.isHyphenated}/>
+                        <FormControlLabel control={<Checkbox />} label="Numbers only" />
+                    </FormGroup>
+                    <FormHelperText>Removing hyphens and making it numeric are irreversible. You can always regenerate a new UUID</FormHelperText>
+                </FormControl>
             </Box>
         );
     }

--- a/frontend/src/content/UuidOptions.js
+++ b/frontend/src/content/UuidOptions.js
@@ -5,12 +5,16 @@ import Box from "@mui/material/Box";
 class UuidChoices extends React.Component   {
     constructor(props) {
         super(props);
-        this.handleChange = this.handleChange.bind(this)
-
+        this.handleCaseChange = this.handleCaseChange.bind(this)
+        this.removeHyphens = this.removeHyphens.bind(this)
     }
 
-    handleChange()  {
-        this.props.onChange();
+    handleCaseChange()  {
+        this.props.onCaseChange();
+    }
+
+    removeHyphens() {
+       this.props.removeHyphens();
     }
 
     render()    {
@@ -26,8 +30,8 @@ class UuidChoices extends React.Component   {
                 <FormGroup row sx={{
                     justifyContent: 'space-evenly'
                 }}>
-                    <FormControlLabel control={<Checkbox />} label="Uppercase" onChange={this.handleChange} />
-                    <FormControlLabel control={<Checkbox />} label="Remove hyphens" />
+                    <FormControlLabel control={<Checkbox />} label="Uppercase" onChange={this.handleCaseChange} />
+                    <FormControlLabel control={<Checkbox />} label="Remove hyphens" onChange={this.removeHyphens} />
                     <FormControlLabel control={<Checkbox />} label="Numbers only" />
                 </FormGroup>
             </Box>

--- a/frontend/src/content/UuidOptions.js
+++ b/frontend/src/content/UuidOptions.js
@@ -1,6 +1,7 @@
-import {Checkbox, FormControl, FormControlLabel, FormGroup, FormHelperText} from "@mui/material";
+import {Checkbox, FormControlLabel, FormGroup} from "@mui/material";
 import * as React from "react";
 import Box from "@mui/material/Box";
+import {Alert} from "@mui/material";
 
 class UuidChoices extends React.Component   {
     constructor(props) {
@@ -27,15 +28,14 @@ class UuidChoices extends React.Component   {
 
     render()    {
         return (
-            <Box component="span" sx={{
-                display: 'flex',
-                justifyContent: 'space-evenly',
-                height: 100,
-                alignItems: 'center',
-                p: 3,
-                m: 2,
-            }}>
-                <FormControl>
+            <Box component="span">
+                <Box component="span" sx={{
+                    display: 'flex',
+                    justifyContent: 'space-evenly',
+                    alignItems: 'center',
+                    p: 3,
+                    m: 2,
+                }}>
                     <FormGroup row sx={{
                         justifyContent: 'space-evenly'
                     }}>
@@ -43,8 +43,16 @@ class UuidChoices extends React.Component   {
                         <FormControlLabel control={<Checkbox />} label="Remove hyphens" onChange={this.removeHyphens} disabled={!this.state.isHyphenated}/>
                         <FormControlLabel control={<Checkbox />} label="Numbers only" />
                     </FormGroup>
-                    <FormHelperText>Removing hyphens and making it numeric are irreversible. You can always regenerate a new UUID</FormHelperText>
-                </FormControl>
+                </Box>
+                <Box component="span" sx={{
+                    display: 'flex',
+                    justifyContent: 'space-evenly',
+                    alignItems: 'center',
+                }}>
+                    <Alert severity="info" variant="outlined" sx={{width: '60%', justifyContent: 'center'}}>
+                        Removing hyphens or choosing numeric UUIDS are irreversible actions. You can always generate a new UUID.
+                    </Alert>
+                </Box>
             </Box>
         );
     }

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -7,6 +7,7 @@ const theme = createTheme({
         },
         text: {
             primary: '#F0F8FF',
+            disabled: '#CD5C5C',
         },
         background: {
             paper: '#28293D',
@@ -42,7 +43,7 @@ const theme = createTheme({
             styleOverrides: {
                 root: {
                     color: '#F0F8FF',
-                }
+                },
             }
         },
         MuiLinearProgress: {
@@ -55,6 +56,13 @@ const theme = createTheme({
                 },
             }
         },
+        MuiFormHelperText: {
+            styleOverrides: {
+                root: {
+                    color: '#CD5C5C',
+                }
+            }
+        }
     },
 });
 

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -56,10 +56,10 @@ const theme = createTheme({
                 },
             }
         },
-        MuiFormHelperText: {
+        MuiAlert: {
             styleOverrides: {
                 root: {
-                    color: '#CD5C5C',
+                    color: '#FFF0F5',
                 }
             }
         }


### PR DESCRIPTION
Implements "remove hyphens" option in the web app. 

With the current implementation, it's not possible to re-insert the hyphens. Instead, an info box is constantly shown and the checkbox is disabled until a new UUID is generated

Closes #24 
